### PR TITLE
Various Fixes

### DIFF
--- a/src/epub/css/local.css
+++ b/src/epub/css/local.css
@@ -250,3 +250,7 @@ p[epub|type~="z3998:stage-direction"] + [epub|type~="z3998:song"]{
 	font-variant: small-caps;
 	font-weight: bold;
 }
+
+#extracts blockquote cite i i{
+	font-style: italic;
+}

--- a/src/epub/text/extracts.xhtml
+++ b/src/epub/text/extracts.xhtml
@@ -58,7 +58,7 @@
 					<cite>Montaigne, “<span epub:type="se:name.publication.essay">Apology for Raimond Sebond</span>.”</cite>
 				</blockquote>
 				<blockquote>
-					<p>“Let us fly, let us fly! Old Nick take me if is not Leviathan described by the noble prophet Moses in the life of patient Job.”</p>
+					<p>“Let us fly, let us fly! Old Nick take me if it is not Leviathan described by the noble prophet Moses in the life of patient Job.”</p>
 					<cite>Rabelais.</cite>
 				</blockquote>
 				<blockquote>

--- a/src/epub/text/extracts.xhtml
+++ b/src/epub/text/extracts.xhtml
@@ -93,7 +93,7 @@
 						<br/>
 						<span>Like as the wounded whale to shore flies thro’ the maine.”</span>
 					</p>
-					<cite><i epub:type="se:name.publication.poem">The Faerie Queen</i>.</cite>
+					<cite><i epub:type="se:name.publication.poem">The Fairie Queen</i>.</cite>
 				</blockquote>
 				<blockquote>
 					<p>“Immense as whales, the motion of whose vast bodies can in a peaceful calm trouble the ocean till it boil.”</p>

--- a/src/epub/text/extracts.xhtml
+++ b/src/epub/text/extracts.xhtml
@@ -197,7 +197,7 @@
 						<br/>
 						<span>God’s voice obey.”</span>
 					</p>
-					<cite><i epub:type="se:name.publication.book"><abbr>N.</abbr> <abbr>E.</abbr> Primer</i>.</cite>
+					<cite><i epub:type="se:name.publication.book"><abbr>N. E.</abbr> Primer</i>.</cite>
 				</blockquote>
 				<blockquote>
 					<p>“We saw also abundance of large whales, there being more in those southern seas, as I may say, by a hundred to one; than we have to the northward of us.”</p>

--- a/src/epub/text/extracts.xhtml
+++ b/src/epub/text/extracts.xhtml
@@ -47,7 +47,7 @@
 				</blockquote>
 				<blockquote>
 					<p>“Scarcely had we proceeded two days on the sea, when about sunrise a great many Whales and other monsters of the sea, appeared. Among the former, one was of a most monstrous size.⁠ ⁠… This came towards us, open-mouthed, raising the waves on all sides, and beating the sea before him into a foam.”</p>
-					<cite>Tooke’s <i epub:type="se:name.publication.book">Lucian</i>. “The True History.”</cite>
+					<cite>Tooke’s <i epub:type="se:name.publication.book">Lucian</i>. <i epub:type="se:name.publication.book">The True History</i>.</cite>
 				</blockquote>
 				<blockquote>
 					<p>“He visited this country also with a view of catching horse-whales, which had bones of very great value for their teeth, of which he brought some to the king.⁠ ⁠… The best whales were catched in his own country, of which some were forty-eight, some fifty yards long. He said that he was one of six who had killed sixty in two days.”</p>
@@ -71,7 +71,7 @@
 				</blockquote>
 				<blockquote>
 					<p>“Touching that monstrous bulk of the whale or ork we have received nothing certain. They grow exceeding fat, insomuch that an incredible quantity of oil will be extracted out of one whale.”</p>
-					<cite><abbr>Ibid.</abbr> “History of Life and Death.”</cite>
+					<cite><abbr>Ibid.</abbr> <i epub:type="se:name.publication.book">History of Life and Death</i>.</cite>
 				</blockquote>
 				<blockquote>
 					<p>“The sovereignest thing on earth is parmacetti for an inward bruise.”</p>
@@ -93,7 +93,7 @@
 						<br/>
 						<span>Like as the wounded whale to shore flies thro’ the maine.”</span>
 					</p>
-					<cite>The Faerie Queen.</cite>
+					<cite><i epub:type="se:name.publication.poem">The Faerie Queen</i>.</cite>
 				</blockquote>
 				<blockquote>
 					<p>“Immense as whales, the motion of whose vast bodies can in a peaceful calm trouble the ocean till it boil.”</p>
@@ -221,7 +221,7 @@
 				</blockquote>
 				<blockquote>
 					<p>“If we compare land animals in respect to magnitude, with those that take up their abode in the deep, we shall find they will appear contemptible in the comparison. The whale is doubtless the largest animal in creation.”</p>
-					<cite>Goldsmith, <abbr>Nat. Hist.</abbr></cite>
+					<cite>Goldsmith, <i epub:type="se:name.publication.book"><abbr>Nat. Hist.</abbr></i></cite>
 				</blockquote>
 				<blockquote>
 					<p>“If you should write a fable for little fishes, you would make them speak like great whales.”</p>
@@ -366,7 +366,7 @@
 				</blockquote>
 				<blockquote>
 					<p>“My God! <abbr>Mr.</abbr> Chace, what is the matter?” I answered, “we have been stove by a whale.”</p>
-					<cite>“Narrative of the Shipwreck of the Whale Ship <i epub:type="se:name.vessel.ship">Essex</i> of Nantucket, which was attacked and finally destroyed by a large Sperm Whale in the Pacific Ocean.” By Owen Chace of Nantucket, first mate of said vessel. New York, 1821.</cite>
+					<cite><i epub:type="se:name.publication.book">Narrative of the Shipwreck of the Whale Ship <i epub:type="se:name.vessel.ship">Essex</i> of Nantucket, which was attacked and finally destroyed by a large Sperm Whale in the Pacific Ocean</i>. By Owen Chace of Nantucket, first mate of said vessel. New York, 1821.</cite>
 				</blockquote>
 				<blockquote epub:type="z3998:verse">
 					<p>


### PR DESCRIPTION
These commits contain various fixes, listed in order:

* Some publication names in the opening extracts aren’t semanticated (4 books and 1 epic poem). In the case of the *Narrative of the Whaleship Essex*, it has been necessary to add an extra selector to `local.css` to properly italicise the ship’s name because of an `<i>` within an `<i>` within a `<cite>` (the only one of its kind on that page).
* Two contiguous abbreviations each contained within their own `<abbr>` have been merged into one element. While it shouldn’t affect the text rendering, it makes sense from a semantic point of view because “N. E. Primer” stands for “New England Primer”. The same page already contains “Nat. Hist.” together in a single `<abbr>` element, so it seems logical and less confusing to do the same for “N. E.”
* An obvious typo has been fixed. Because it adds a missing word (present in source scans but missing from the Gutenberg transcription), it should modify the word count, which hasn’t been updated.
* The extracts contain a quote from Spenser’s *The Faerie Queene*—this is the canonical spelling of the work’s title. The Gutenberg transcription spells it as *The Faerie Queen* but source scans use *The Fairie Queen* (probably Melville’s own choice), as do other editions whose scans are available online. Only the Gutenberg transcription (and by extension the current SE edition) use the *Faerie* spelling. This may have been a possible mistake on the part of the transcribers.
